### PR TITLE
hubot-google-transliterate

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -3,5 +3,6 @@
   "hubot-tantanmen",
   "hubot-sushiyuki",
   "hubot-phonetic-alphabet",
-  "hubot-53cal-jp"
+  "hubot-53cal-jp",
+  "hubot-google-transliterate"
 ]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gitio": ">= 1.0.1",
     "hubot": ">= 2.6.0 < 3.0.0",
     "hubot-53cal-jp": "^0.2.0",
+    "hubot-google-transliterate": "^0.1.0",
     "hubot-phonetic-alphabet": "^0.1.0",
     "hubot-scripts": ">= 2.5.0 < 3.0.0",
     "hubot-slack ": ">= 2.1.0",


### PR DESCRIPTION
`hubot google (input|transliterate) <word>`でひらがな -> google日本語検索の結果を返す 郵便番号 -> 住所変換もできる

```
user1>> hubot google transliterate かんだ
hubot>> @user1 神田
user1>> hubot google input 140-0013
hubot>> @user1 東京都品川区南大井
```
