### PR TITLE
Add seo bot

### DIFF
--- a/scripts/seo.coffee
+++ b/scripts/seo.coffee
@@ -5,7 +5,7 @@
 #   "underscore": ">= 1.6.0",
 #
 # Configuration:
-#   SEO_MEMBERS
+#   SEO_ENGINEERS
 #
 # Commands:
 #   hubot seo [message] - post the message to all SEO team members
@@ -13,7 +13,7 @@
 
 _ = require 'underscore'
 
-members = process.env.SEO_MEMBERS?.split(/\s/) || []
+members = process.env.SEO_ENGINEERS?.split(/\s/) || []
 mentions = ->
   ((_.shuffle members).map (name) -> "@#{name}").join(' ')
 


### PR DESCRIPTION
SEO チームメンバーを召喚する bot を作りました。
`hubot seo メッセージ` で、メンバー全員にメンションするポストを投げます。

メンションの順が毎回ランダムになるところがポイントです。
(朝会/夕会の発言順の決定を兼ねております)

環境変数 SEO_MEMBERS が必要です。

``` bash
SEO_MEMBERS='foo bar baz'  # 空白区切り、「@」なしの Slack ユーザー名
```

みたいにしてください。
